### PR TITLE
Resolve hostnames for STT server using DNS

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -46,6 +46,7 @@ redis_url = "redis://localhost:6379"
 # Target services: you usually only have one, and
 # it's usually on localhost port 7269
 stt_services = [
+  "localhost:7269",    # or:
   ["127.0.0.1", 7269]
 ]
 

--- a/scripty_config/src/cfg.rs
+++ b/scripty_config/src/cfg.rs
@@ -96,7 +96,6 @@ pub enum BotListsConfig {
 	FullConfig { token: String, webhook: String },
 }
 
-
 #[cfg(test)]
 mod tests {
 	use std::{

--- a/scripty_stt/src/load_balancer.rs
+++ b/scripty_stt/src/load_balancer.rs
@@ -42,9 +42,11 @@ impl LoadBalancer {
 						.await
 						.expect("Could not resolve stt hostname"),
 				),
-				SttServiceDefinition::IPTuple(addr, port) => {
-					peer_addresses.push(SocketAddr::new(addr.parse().expect("Could not parse IP address for stt server"), port))
-				}
+				SttServiceDefinition::IPTuple(addr, port) => peer_addresses.push(SocketAddr::new(
+					addr.parse()
+						.expect("Could not parse IP address for stt server"),
+					port,
+				)),
 			}
 		}
 


### PR DESCRIPTION
I've been setting up the scripty services using docker-compose, which assigns different containers stable hostnames but not necessarily static IPs. This PR allows the user to specify a "hostname:port" string in addition to a ["ip", port] tuple in their stt_services config. It shouldn't require any changes to existing config files (although the existing format never worked for me so I can't actually test that).