### PR TITLE
fix: top.gg vote url and typo

### DIFF
--- a/scripty_bot_utils/src/background_tasks/tasks/bot_vote_reminder.rs
+++ b/scripty_bot_utils/src/background_tasks/tasks/bot_vote_reminder.rs
@@ -104,7 +104,7 @@ impl fmt::Display for VoteList {
 impl VoteList {
 	pub fn vote_url(&self) -> &'static str {
 		match self {
-			Self::TopGg => "https://top.gg/bot/699453633624064849/vote",
+			Self::TopGg => "https://top.gg/bot/811652199100317726/vote",
 			Self::DiscordServicesNet => "https://discordservices.net/bot/scripty",
 			Self::WumpusStore => "https://wumpus.store/bot/811652199100317726/vote",
 		}

--- a/scripty_webserver/src/endpoints/webhooks/discordservices_net.rs
+++ b/scripty_webserver/src/endpoints/webhooks/discordservices_net.rs
@@ -92,7 +92,7 @@ pub async fn discordservices_net_incoming_webhook(
 					.title("Thanks for voting for Scripty on discordservices.net!")
 					.description(
 						"You can vote again in 20 hours. We'll send you a reminder then. If you \
-						 don't want to be notified, run `/vote_reminders False`. Thanks for your \
+						 don't want to be notified, run `/vote_reminders: False`. Thanks for your \
 						 support!",
 					),
 			),

--- a/scripty_webserver/src/endpoints/webhooks/top_gg.rs
+++ b/scripty_webserver/src/endpoints/webhooks/top_gg.rs
@@ -83,7 +83,7 @@ pub async fn top_gg_incoming_webhook(
 					.title("Thanks for voting for Scripty on top.gg!")
 					.description(
 						"You can vote again in 12 hours. We'll send you a reminder then. If you \
-						 don't want to be notified, run `/vote_reminders False`. Thanks for your \
+						 don't want to be notified, run `/vote_reminders: False`. Thanks for your \
 						 support!",
 					)
 					.footer(CreateEmbedFooter::new(if kind.is_test() {

--- a/scripty_webserver/src/endpoints/webhooks/wumpus_store.rs
+++ b/scripty_webserver/src/endpoints/webhooks/wumpus_store.rs
@@ -90,7 +90,7 @@ pub async fn wumpus_store_incoming_webhook(
 					.title("Thanks for voting for Scripty on wumpus.store!")
 					.description(
 						"You can vote again in 12 hours. We'll send you a reminder then. If you \
-						 don't want to be notified, run `/vote_reminders False`. Thanks for your \
+						 don't want to be notified, run `/vote_reminders: False`. Thanks for your \
 						 support!",
 					)
 					.footer(CreateEmbedFooter::new(if webhook_test {


### PR DESCRIPTION
This fixes the top.gg vote url to actually include the correct id.